### PR TITLE
Update clockwork.go, fixed time drift

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -440,8 +440,7 @@ func (s *Scheduler) Run() {
 				go job.workFunc()
 			}
 		}
-		time.Sleep(1 * time.Second)
-
+		time.Sleep(333 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
decreased sleep time to 333 mili seconds in the Run() function to fix to slow time drift introduced by sleeping 1 second