### PR TITLE
fixed some TODO's

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -135,7 +135,7 @@ func (j *Job) scheduleNextRun() error {
 	// At() can be used only with day and WEEKDAY
 	if j.frequency == 1 {
 
-		// Panic if usage of "At()" is incorrect
+		// return an error if usage of "At()" is incorrect
 		if j.isAtUsedIncorrectly() {
 			return errors.New("Cannot schedule Every(1) with At() when unit is not day or WEEKDAY")
 		}


### PR DESCRIPTION
the scheduler now returns an error instead of trowing a panic. This makes it the users responsibility to check for scheduling errors.

checking for errors can be done in the following way.

```
err := sched.Run()
if err != nil {
    log.Println(err)
}
```